### PR TITLE
Logic Updates

### DIFF
--- a/resources/data/Randomizer/doors.json
+++ b/resources/data/Randomizer/doors.json
@@ -902,7 +902,7 @@
 		"Type": 1,
 		"VisibilityFlags": 11,
 		"RequiredDoors": [ "D01Z05S25[EchoesE]" ],
-		"Logic": "D01Z05S25[EchoesW] || (D01Z05S25[EchoesE] && (blood || canCrossGap8)) || (linen && doubleJump)"
+		"Logic": "D01Z05S25[EchoesW] || D01Z05S25[EchoesE] && (blood || canCrossGap8) || linen && (canCrossGap5 || canAirStall && blood)"
 	},
 	{
 		"Id": "D01Z05S25[EchoesE]",
@@ -911,7 +911,7 @@
 		"Type": 1,
 		"VisibilityFlags": 11,
 		"RequiredDoors": [ "D01Z05S25[EchoesW]" ],
-		"Logic": "D01Z05S25[EchoesE] || (D01Z05S25[EchoesW] && (blood || canCrossGap8)) || (linen && doubleJump)"
+		"Logic": "D01Z05S25[EchoesE] || D01Z05S25[EchoesW] && (blood || canCrossGap8) || linen && (canCrossGap5 || canAirStall && blood)"
 	},
 	{
 		"Id": "D01Z05S26[W]",
@@ -2005,13 +2005,13 @@
 		"Id": "D03Z02S11[W]",
 		"Direction": 1,
 		"OriginalDoor": "D03Z02S05[E]",
-		"Logic": "D03Z02S11[W] || dash && (doubleJump || wallClimb || canCrossGap2)"
+		"Logic": "D03Z02S11[W] || dash && (canCrossGap1 || wallClimb)"
 	},
 	{
 		"Id": "D03Z02S11[E]",
 		"Direction": 2,
 		"OriginalDoor": "D03Z02S15[W]",
-		"Logic": "D03Z02S11[E] || dash && (wallClimb || doubleJump)"
+		"Logic": "D03Z02S11[E] || dash && (wallClimb || doubleJump || canCrossGap2 && canEnemyBounce)"
 	},
 	{
 		"Id": "D03Z02S12[E]",
@@ -2126,7 +2126,7 @@
 		"Id": "D03Z03S04[NE]",
 		"Direction": 2,
 		"OriginalDoor": "D03Z03S05[NW]",
-		"Logic": "D03Z03S04[NE] || wallClimb && (D03Z03S04[NW] || D03Z03S04[E] || D03Z03S04[SW] || blood || canCrossGap10)"
+		"Logic": "D03Z03S04[NE] || (wallClimb || doubleJump && canEnemyBounce) && (D03Z03S04[NW] || D03Z03S04[E] || D03Z03S04[SW] || blood || canCrossGap10)"
 	},
 	{
 		"Id": "D03Z03S04[E]",

--- a/resources/data/Randomizer/doors.json
+++ b/resources/data/Randomizer/doors.json
@@ -2005,7 +2005,7 @@
 		"Id": "D03Z02S11[W]",
 		"Direction": 1,
 		"OriginalDoor": "D03Z02S05[E]",
-		"Logic": "D03Z02S11[W] || dash && (canCrossGap1 || wallClimb)"
+		"Logic": "D03Z02S11[W] || dash && (wallClimb || canCrossGap2 || preciseSkipsAllowed && canCrossGap1)"
 	},
 	{
 		"Id": "D03Z02S11[E]",

--- a/resources/data/Randomizer/locations_items.json
+++ b/resources/data/Randomizer/locations_items.json
@@ -557,7 +557,7 @@
 		"Name": "Elevator shaft ledge",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S25",
-		"Logic": "linen || D01Z05S25[SW] && doubleJump"
+		"Logic": "linen || doubleJump && (D01Z05S25[SW] || D01Z05S25[SE] || D01Z05S25[NE])"
 	},
 	{
 		"Id": "RESCUED_CHERUB_22",

--- a/resources/data/Randomizer/locations_items.json
+++ b/resources/data/Randomizer/locations_items.json
@@ -126,7 +126,7 @@
 		"Name": "Elevator cherub",
 		"Hint": "* resides in Albero",
 		"Room": "D01Z02S03",
-		"Logic": "rodeGotPElevator || pillar || cante || D01Z02S03[NW] && (canCrossGap2 || lorquiana || aubade || cantina || canAirStall || chargeBeam)"
+		"Logic": "rodeGotPElevator || pillar || cante || doubleJump || D01Z02S03[NW] && (canCrossGap1 || lorquiana || aubade || cantina || chargeBeam)"
 	},
 	{
 		"Id": "Lvdovico[500]",
@@ -557,14 +557,14 @@
 		"Name": "Elevator shaft ledge",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S25",
-		"Logic": "linen"
+		"Logic": "linen || D01Z05S25[SW] && doubleJump"
 	},
 	{
 		"Id": "RESCUED_CHERUB_22",
 		"Name": "Elevator shaft cherub",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S25",
-		"Logic": "linen || (pillar && (D01Z05S25[E] || D01Z05S25[W] && (canWalkOnRoot || canCrossGap3)))"
+		"Logic": "linen || D01Z05S25[SW] && (aubade || cantina) || (pillar && (D01Z05S25[E] || D01Z05S25[W] && (canWalkOnRoot || canCrossGap3)))"
 	},
 	{
 		"Id": "Lady[D01Z05S26]",
@@ -646,7 +646,7 @@
 		"Name": "Large cave cherub",
 		"Hint": "* resides with the Olive Trees",
 		"Room": "D02Z01S06",
-		"Logic": "(D02Z01S06[W] || dash || doubleJump && wallClimb) && (pillar || cante) || (D02Z01S06[W] || doubleJump || dash) && wallClimb && (lorquiana || aubade || cantina || canAirStall)"
+		"Logic": "(D02Z01S06[W] && (pillar || cante || canDiveLaser) || (D02Z01S06[W] || doubleJump || dash) && wallClimb && (lorquiana || aubade || cantina || canAirStall)"
 	},
 	{
 		"Id": "PR04",
@@ -689,7 +689,7 @@
 		"Name": "Eastern shaft upper",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S03",
-		"Logic": "(canClimbOnRoot && doubleJump) || (blood && (doubleJump || canClimbOnRoot))"
+		"Logic": "canClimbOnRoot && (D02Z02S03[NE] || doubleJump || blood) || blood && doubleJump"
 	},
 	{
 		"Id": "RB32",
@@ -737,7 +737,7 @@
 		"Name": "Shop cave cherub",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S08",
-		"Logic": "D02Z02S08[CherubsR] || blood || pillar || canCrossGap8"
+		"Logic": "D02Z02S08[CherubsR] || canDiveLaser || blood || pillar || canCrossGap8"
 	},
 	{
 		"Id": "Oil[D02Z02S10]",
@@ -979,8 +979,7 @@
 		"Id": "CO07",
 		"Name": "Western shaft lower slide",
 		"Hint": "* resides in the Bell",
-		"Room": "D03Z02S07",
-		"Logic": "dash"
+		"Room": "D03Z02S07"
 	},
 	{
 		"Id": "QI41",
@@ -1000,14 +999,14 @@
 		"Name": "Spike tunnel ledge",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S11",
-		"Logic": "dash && (wallClimb || doubleJump || D03Z02S11[E] && canCrossGap2)"
+		"Logic": "D03Z02S11[W] && doubleJump || D03Z02S11[E] && dash && (canCrossGap1 || wallClimb)"
 	},
 	{
 		"Id": "RESCUED_CHERUB_37",
 		"Name": "Spike tunnel cherub",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S11",
-		"Logic": "dash && (wallClimb || doubleJump || D03Z02S11[W] && (canCrossGap2 && canEnemyBounce || canCrossGap3) || D03Z02S11[E] && (canCrossGap1 || canEnemyBounce))"
+		"Logic": "D03Z02S11[W] && (doubleJump || dash && (wallClimb || canCrossGap2 && canEnemyBounce || canCrossGap3)) || D03Z02S11[E] && dash && (canCrossGap1 || wallClimb || canEnemyBounce))"
 	},
 	{
 		"Id": "QI52",
@@ -1055,7 +1054,7 @@
 		"Name": "Lung room cherub",
 		"Hint": "* resides in the Grievance",
 		"Room": "D03Z03S06",
-		"Logic": "wallClimb"
+		"Logic": "wallClimb || canCrossGap11 && tirana"
 	},
 	{
 		"Id": "QI10",

--- a/resources/data/Randomizer/locations_items.json
+++ b/resources/data/Randomizer/locations_items.json
@@ -999,7 +999,7 @@
 		"Name": "Spike tunnel ledge",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S11",
-		"Logic": "D03Z02S11[W] && doubleJump || D03Z02S11[E] && dash && (canCrossGap1 || wallClimb)"
+		"Logic": "D03Z02S11[W] && doubleJump || D03Z02S11[E] && dash && (wallClimb || canCrossGap2 || preciseSkipsAllowed && canCrossGap1)"
 	},
 	{
 		"Id": "RESCUED_CHERUB_37",

--- a/resources/data/Randomizer/locations_items.json
+++ b/resources/data/Randomizer/locations_items.json
@@ -564,7 +564,7 @@
 		"Name": "Elevator shaft cherub",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S25",
-		"Logic": "linen || D01Z05S25[SW] && (aubade || cantina) || (pillar && (D01Z05S25[E] || D01Z05S25[W] && (canWalkOnRoot || canCrossGap3)))"
+		"Logic": "linen || (obscureSkipsAllowed && (D01Z05S25[SW] || D01Z05S25[SE] || D01Z05S25[NE]) && (aubade || cantina)) || (pillar && (D01Z05S25[E] || D01Z05S25[W] && (canWalkOnRoot || canCrossGap3)))"
 	},
 	{
 		"Id": "Lady[D01Z05S26]",

--- a/resources/data/Randomizer/locations_items.json
+++ b/resources/data/Randomizer/locations_items.json
@@ -1054,7 +1054,7 @@
 		"Name": "Lung room cherub",
 		"Hint": "* resides in the Grievance",
 		"Room": "D03Z03S06",
-		"Logic": "wallClimb || canCrossGap11 && tirana"
+		"Logic": "wallClimb || canCrossGap11 && taranto && obscureSkipsAllowed"
 	},
 	{
 		"Id": "QI10",


### PR DESCRIPTION
These are my attempts at logic updates to address some parts of [issue 9](https://github.com/BrandenEK/Blasphemous-Randomizer/issues/9). Please note that I am not entirely used to the way Blasphemous logic is written out, so some of these changes may be stylistically clashing and that these changes **are not tested**, as I'm not sure how I would actually do that.
This does _not_ address the White lady cave "Large cave ledge" logic errors, or the [WotHP elevator logic](https://discord.com/channels/731205301247803413/1090815418731597884/1131316218876411904).
Also note that "Western shaft lower slide" could perhaps use a name change as it no longer requires slide but "Western shaft lower" was already taken, so I wasn't sure what to change it to.