### PR TITLE
Fix PotSS Garden 3 Upper Ledge logic

### DIFF
--- a/resources/data/Randomizer/locations_items.json
+++ b/resources/data/Randomizer/locations_items.json
@@ -1142,7 +1142,7 @@
 		"Name": "Garden 3 upper ledge",
 		"Hint": "* resides in the Patio",
 		"Room": "D04Z01S03",
-		"Logic": "canWalkOnRoot || canCrossGap3"
+		"Logic": "canClimbOnRoot || canCrossGap3"
 	},
 	{
 		"Id": "RESCUED_CHERUB_28",


### PR DESCRIPTION
Root alone is insufficient for reaching this ledge - climb would be required too.

![PotSS Garden 3 upper ledge logic](https://github.com/BrandenEK/Blasphemous-Randomizer/assets/132797076/5653d170-d6eb-4c9f-9efb-da890ff4d3e5)
